### PR TITLE
Non-carcinogens/Carcinogens, Toxicity Equivalency Factors tools. Addresses Ryan's email on August 22, 2017

### DIFF
--- a/src/carc-params.js
+++ b/src/carc-params.js
@@ -52,5 +52,6 @@ export default {
     IFprod: [60368875, 60368875],
     IFpltry: [10780000, 10780000]
   },
-  chemical: 'TCDD, 2,3,7,8-'
+  chemical: { },
+  chemicalName: 'TCDD, 2,3,7,8-'
 }

--- a/src/components/Carcinogens.vue
+++ b/src/components/Carcinogens.vue
@@ -4,7 +4,10 @@
     button.btn.btn-danger(type='button', @click="clear") Clear Parameter Values
     button.btn(type='button', @click="collapse") Show/Hide Formulae
 
-    h2 Receptor Profile: {{params.profile}} - {{params.chemical}}
+    h2 
+      span Receptor Profile: {{params.profile}}
+      br
+      span Chemical: {{params.chemicalName}}
 
     values-table(:params='params', @update='setParams')
 

--- a/src/components/NonCarcinogens.vue
+++ b/src/components/NonCarcinogens.vue
@@ -2,9 +2,12 @@
   div
     button.btn.btn-primary(type='button', data-toggle='modal', data-target='#values') Set Parameter Values
     button.btn.btn-danger(type='button', @click="clear") Clear Parameter Values
-    button(type='button', @click="collapse") Show/Hide Formulae
+    button.btn(type='button', @click="collapse") Show/Hide Formulae
 
-    h2 Receptor Profile: {{params.profile}} - {{params.chemical}}
+    h2 
+      span Receptor Profile: {{params.profile}}
+      br
+      span Chemical: {{params.chemicalName}}
 
     values-table(:params='params', @update='setParams')
 

--- a/src/components/ParamField.vue
+++ b/src/components/ParamField.vue
@@ -20,7 +20,6 @@
     },
     methods: {
       updateValue (value) {
-        this.$refs.input.value = value
         this.$emit('input', value)
       }
     }

--- a/src/components/ToxicityCalculator.vue
+++ b/src/components/ToxicityCalculator.vue
@@ -18,9 +18,9 @@
             button.btn.btn-danger(@click='chemicals[group].splice(i, 1) && save()') x
           td {{chemical['Chemical']}}
           td
-            input(v-model='chemical["Concentration"]', @input='save')
+            input(v-model='chemical["Concentration"]', @input='save(chemical)')
           td {{chemical['TEF']}}
-          td {{Math.round(chemical['TEF'] * chemical['Concentration'] * 1000000) / 1000000}}
+          td {{chemical['TEQ']}}
       tfoot
         tr
           td(colspan='4') SUM TEQ
@@ -53,7 +53,10 @@ export default {
     }
   },
   methods: {
-    save () {
+    save (chemical) {
+      if (chemical) {
+        chemical['TEQ'] = Math.round(chemical['TEF'] * chemical['Concentration'] * 1000000) / 1000000
+      }
       window.localStorage.setItem('chemicals', JSON.stringify(this.chemicals))
     },
     reset () {

--- a/src/components/ToxicityCalculator.vue
+++ b/src/components/ToxicityCalculator.vue
@@ -57,8 +57,9 @@ export default {
       window.localStorage.setItem('chemicals', JSON.stringify(this.chemicals))
     },
     reset () {
-      window.localStorage.setItem('chemicals', '{}')
-      this.chemicals = JSON.parse(JSON.stringify(this.original))
+      let originalJson = JSON.stringify(this.original)
+      this.chemicals = JSON.parse(originalJson)
+      window.localStorage.setItem('chemicals', originalJson)
     }
   },
   mounted () {

--- a/src/components/ValuesTable.vue
+++ b/src/components/ValuesTable.vue
@@ -10,7 +10,7 @@
           label(for='chemical') Chemical: &nbsp;
           select(v-model='chemical', @change='setChemical($event.target)')
             optgroup(v-for='g in Object.keys(chemicals)' :label='g')
-              option(v-for='c in Object.keys(chemicals[g])' :value='chemicals[g][c]') {{c}}
+              option(v-for='c in Object.keys(chemicals[g])' :value='chemicals[g][c]' :label='c') {{c}}
 
           table.table
             tr
@@ -50,6 +50,7 @@
         col: null,
         chemicals: chemicals,
         chemical: {},
+        chemicalName: '',
         firstRun: true
       }
     },
@@ -75,6 +76,7 @@
         this.firstRun = false
       },
       setChemical (target) {
+        this.params.chemicalName = target.options[target.selectedIndex].text
         this.params.chemical = target.options[target.selectedIndex].value
         Object.keys(this.chemical).forEach(c => {
           if (this.params[c]) {
@@ -85,7 +87,8 @@
     },
     mounted () {
       this.$el.querySelectorAll('td')[3].click()
-      this.chemical = this.chemicals['Dioxins'][this.params.chemical]
+      this.chemical = this.chemicals['Dioxins'][this.params.chemicalName]
+      this.chemicalName = this.params.chemicalName
     }
   }
 </script>

--- a/src/nc-params.js
+++ b/src/nc-params.js
@@ -55,5 +55,6 @@ export default {
     IRpltry: [11550, 61600],
     IRwater: [0.78, 2.5, null, null, 0.12, 0.071]
   },
-  chemical: 'TCDD, 2,3,7,8-'
+  chemical: { },
+  chemicalName: 'TCDD, 2,3,7,8-'
 }


### PR DESCRIPTION
Implemented changes from Ryan's email on August 22, 2017.
Fixed:
http://usaid.popstoolkit.com/index.php/risk-assessment/m3-risk-calculation-tools/non-carcinogens
•	Chemical name not showing properly under “Receptor Profile”
•	I would prefer if it said “Receptor Profile” and then said “Chemical”
•	HI should be under the HQ column (because we are adding here)
•	Allow entering of certain values in scientific notation (right now the cell goes blank if we enter an “e”). The values that need to be enterable in scientific notation are all concentration values (Cx), VF and PEF. 
 
http://usaid.popstoolkit.com/index.php/risk-assessment/m3-risk-calculation-tools/carcinogens
•	Chemical name not showing properly under “Receptor Profile”
•	I would prefer if it said “Receptor Profile” and then said “Chemical”
•	ICLRtot should be under the ILCR (because we are adding here)
•	Allow entering of certain values in scientific notation (right now the cell goes blank if we enter an “e”). The values that need to be enterable in scientific notation are all concentration values (Cx), VF and PEF. 
 
http://usaid.popstoolkit.com/index.php/risk-assessment/toxicity-assessment/toxicity-equivalency-factors
•	Individual lines appear to be working in the calculator. 
•	But the total isn’t working – this is more of a major issue, but I suspect one that is a simple fix. 
 

